### PR TITLE
fix(chat): onReceiveLocationUpdateCallback conflict

### DIFF
--- a/common/src/services/hub.ts
+++ b/common/src/services/hub.ts
@@ -321,7 +321,7 @@ export class HubServiceClient extends AbstractHubService {
     return {
       closed: this.onReceiveLocationUpdateCallback !== callback,
       unsubscribe: async () => {
-        this.onReceiveLatestMessagesCallback = null;
+        this.onReceiveLocationUpdateCallback = undefined;
       }
     };
   }


### PR DESCRIPTION
Le chat d'un trajet était vide. Après investigation, je pense que cela vient d'un conflit avec LocationUpdateCallback. A confirmer que je n'ai pas supprimé un comportement voulu