### PR TITLE
Feat apercu projet

### DIFF
--- a/app/src/components/DayOfTheWeekPicker.tsx
+++ b/app/src/components/DayOfTheWeekPicker.tsx
@@ -16,7 +16,8 @@ export const DayOfTheWeekPicker = ({
   daysSize,
   enabledDays,
   borderBottomDisplayed = false,
-  singleOptionMode = false
+  singleOptionMode = false,
+  dualOptionMode = false
 }: {
   selectedDays: DayOfWeekFlag | null;
   onChangeDays: (daysOfTheWeek: DayOfWeekFlag) => void;
@@ -25,6 +26,7 @@ export const DayOfTheWeekPicker = ({
   borderBottomDisplayed?: boolean;
   enabledDays?: DayOfWeekFlag;
   singleOptionMode?: boolean;
+  dualOptionMode?: boolean;
 }) => {
   const selectedDaysString = selectedDays ?? "0000000";
   const size = daysSize ?? 35;
@@ -36,11 +38,31 @@ export const DayOfTheWeekPicker = ({
     AppLocalization.daysList.forEach((_day: string, index: number) => {
       // Replace selected day at selected index
       newSelectedDays +=
-        index === dayIndex ? replaceSelectedDay(currentSelectedDays.charAt(index)) : singleOptionMode ? "0" : currentSelectedDays.charAt(index);
+        index === dayIndex
+          ? replaceSelectedDay(currentSelectedDays.charAt(index))
+          : singleOptionMode
+          ? "0"
+          : dualOptionMode
+          ? countAvailableDays(currentSelectedDays) > 1
+            ? "0"
+            : currentSelectedDays.charAt(index)
+          : currentSelectedDays.charAt(index);
     });
 
     onChangeDays(newSelectedDays as DayOfWeekFlag);
   };
+
+  const countAvailableDays = (weekdays: string): number => {
+    let availableDaysCount = 0;
+    for (let i = 0; i < weekdays.length; i++) {
+      if (weekdays[i] === "1") {
+        availableDaysCount++;
+      }
+    }
+
+    return availableDaysCount;
+  };
+
   return (
     <View>
       <Row style={styles.rowContainer} spacing={6}>

--- a/app/src/components/trip/TripSurveyView.tsx
+++ b/app/src/components/trip/TripSurveyView.tsx
@@ -1,4 +1,4 @@
-import { ActivityIndicator, Pressable, StyleSheet, View } from "react-native";
+import { ActivityIndicator, StyleSheet, View } from "react-native";
 import { AppText } from "@/components/base/AppText.tsx";
 import { AppColorPalettes, AppColors } from "@/theme/colors.ts";
 import { AppLocalization } from "@/api/i18n.ts";
@@ -23,7 +23,6 @@ import { useQuery, useQueryClient } from "react-query";
 import { JoinRequestDetailQueryKey, JoinRequestsQueryKey, LianeDetailQueryKey, LianeQueryKey } from "@/screens/user/MyTripsScreen.tsx";
 import { AppContext } from "@/components/context/ContextProvider.tsx";
 import { AppStorage } from "@/api/storage.ts";
-import { de } from "@faker-js/faker";
 import { LianeStatusView } from "@/components/trip/LianeStatusView.tsx";
 import { SimpleModal } from "@/components/modal/SimpleModal.tsx";
 import { DayOfTheWeekPicker } from "@/components/DayOfTheWeekPicker.tsx";

--- a/app/src/screens/communities/CommunitiesChatScreen.tsx
+++ b/app/src/screens/communities/CommunitiesChatScreen.tsx
@@ -439,8 +439,6 @@ const getNextAvailableDay = (weekdays: string, start: StartTime): string => {
   // If the current day is available but the current time is before the start time
   if (weekdays[currentDay] === "1" && (currentHour < start.hour || (currentHour === start.hour && currentMinute < start.minute))) {
     nextDayIndex = currentDay;
-  } else {
-    nextDayIndex = findNextDay(currentDay + 1);
   }
 
   if (nextDayIndex === -1) {

--- a/app/src/screens/communities/CommunitiesChatScreen.tsx
+++ b/app/src/screens/communities/CommunitiesChatScreen.tsx
@@ -6,14 +6,12 @@ import {
   CoMatch,
   DayOfWeekFlag,
   LianeMessage,
-  LianeRequest,
   MatchGroup,
   MatchSingle,
   PaginatedResponse,
   RallyingPoint,
   ResolvedLianeRequest,
-  User,
-  WayPoint
+  User
 } from "@liane/common";
 import React, { useContext, useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, FlatList, KeyboardAvoidingView, Platform, Pressable, StyleSheet, View } from "react-native";
@@ -149,14 +147,6 @@ export const CommunitiesChatScreen = () => {
 
   const name = !liane?.name && me ? `${me.lianeRequest.wayPoints[0].label}  ➔ ${me.lianeRequest.wayPoints[1].label}` : liane?.name;
 
-  const nextDayIndex = useMemo(() => {
-    const todayIndex = (new Date().getDay() + 6) % 7;
-    if (!me) {
-      return todayIndex;
-    } else {
-      return todayIndex + me.lianeRequest.weekDays.substring(todayIndex).concat(me.lianeRequest.weekDays.substring(0, todayIndex)).indexOf("1");
-    }
-  }, [me]);
   const startDate = useMemo(() => {
     const d = new Date();
     if (!me || me.lianeRequest.timeConstraints.length === 0) {

--- a/app/src/screens/communities/CommunitiesChatScreen.tsx
+++ b/app/src/screens/communities/CommunitiesChatScreen.tsx
@@ -6,6 +6,7 @@ import {
   CoMatch,
   DayOfWeekFlag,
   LianeMessage,
+  LianeRequest,
   MatchGroup,
   MatchSingle,
   PaginatedResponse,
@@ -402,7 +403,7 @@ export const CommunitiesChatScreen = () => {
         {!!me && (
           <LaunchTripModal
             nextDayIndex={nextDayIndex}
-            weekdays={me!.lianeRequest.weekDays}
+            lianeRequest={me!.lianeRequest}
             tripModalVisible={tripModalVisible}
             setTripModalVisible={setTripModalVisible}
             launchTrip={launchTrip}
@@ -418,17 +419,20 @@ const LaunchTripModal = ({
   tripModalVisible,
   setTripModalVisible,
   launchTrip,
-  weekdays,
+  lianeRequest,
   nextDayIndex,
   initialDate
 }: {
   initialDate: Date;
-  weekdays: DayOfWeekFlag;
+  lianeRequest: ResolvedLianeRequest;
   tripModalVisible: boolean;
   setTripModalVisible: (v: boolean) => void;
   launchTrip: (d: [Date, Date | undefined]) => void;
   nextDayIndex: number;
 }) => {
+  const weekdays = lianeRequest.weekDays;
+  console.log("Init params", lianeRequest);
+
   const [launchTripStep, setLaunchTripStep] = useState(0);
   const [selectedTime, setSelectedTime] = useState<[Date, Date | undefined]>([new Date(), undefined]);
   // @ts-ignore

--- a/app/src/screens/communities/CommunitiesChatScreen.tsx
+++ b/app/src/screens/communities/CommunitiesChatScreen.tsx
@@ -10,8 +10,10 @@ import {
   MatchGroup,
   MatchSingle,
   PaginatedResponse,
+  RallyingPoint,
   ResolvedLianeRequest,
-  User
+  User,
+  WayPoint
 } from "@liane/common";
 import React, { useContext, useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, FlatList, KeyboardAvoidingView, Platform, Pressable, StyleSheet, View } from "react-native";
@@ -164,15 +166,15 @@ export const CommunitiesChatScreen = () => {
     d.setHours(c.hour, c.minute);
     return d;
   }, [me]);
-  const launchTrip = async (time: [Date, Date | undefined]) => {
+  const launchTrip = async (time: [Date, Date | undefined], from: string | undefined, to: string | undefined) => {
     setTripModalVisible(false);
     const geolocationLevel = await AppStorage.getSetting("geolocation");
 
     const created = await services.liane.post({
       departureTime: time[0].toISOString(),
       returnTime: time[1]?.toISOString(),
-      from: me!.lianeRequest.wayPoints[0].id!,
-      to: me!.lianeRequest.wayPoints[1].id!,
+      from: from ?? me!.lianeRequest.wayPoints[0].id!,
+      to: to ?? me!.lianeRequest.wayPoints[1].id!,
       availableSeats: me!.lianeRequest.canDrive ? 1 : -1,
       geolocationLevel: geolocationLevel || "None",
       recurrence: undefined
@@ -402,7 +404,6 @@ export const CommunitiesChatScreen = () => {
 
         {!!me && (
           <LaunchTripModal
-            nextDayIndex={nextDayIndex}
             lianeRequest={me!.lianeRequest}
             tripModalVisible={tripModalVisible}
             setTripModalVisible={setTripModalVisible}
@@ -415,39 +416,109 @@ export const CommunitiesChatScreen = () => {
   );
 };
 
+type StartTime = {
+  hour: number;
+  minute: number;
+};
+
+const getNextAvailableDay = (weekdays: string, start: StartTime): string => {
+  if (weekdays.length !== 7) {
+    throw new Error("La chaîne weekdays doit contenir 7 caractères.");
+  }
+  if (!/^[01]{7}$/.test(weekdays)) {
+    throw new Error("La chaîne weekdays doit contenir uniquement des 0 et des 1.");
+  }
+
+  const now = new Date();
+  const currentDay = (now.getDay() + 6) % 7;
+  const currentHour = now.getHours();
+  const currentMinute = now.getMinutes();
+
+  function findNextDay(startIndex: number): number {
+    for (let i = 0; i < 7; i++) {
+      const dayIndex = (startIndex + i) % 7;
+      if (weekdays[dayIndex] === "1") {
+        return dayIndex;
+      }
+    }
+    return -1;
+  }
+
+  let nextDayIndex = findNextDay(currentDay);
+
+  // If the current day is available but the current time is before the start time
+  if (weekdays[currentDay] === "1" && (currentHour < start.hour || (currentHour === start.hour && currentMinute < start.minute))) {
+    nextDayIndex = currentDay;
+  } else {
+    nextDayIndex = findNextDay(currentDay + 1);
+  }
+
+  if (nextDayIndex === -1) {
+    throw new Error("Aucun jour disponible trouvé.");
+  }
+
+  const result = "0000000".split("");
+  result[nextDayIndex] = "1";
+
+  return result.join("");
+};
+
+const createDateFromStart = (start: StartTime): Date => {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate(), start.hour, start.minute, 0, 0);
+};
+
 const LaunchTripModal = ({
   tripModalVisible,
   setTripModalVisible,
   launchTrip,
   lianeRequest,
-  nextDayIndex,
   initialDate
 }: {
   initialDate: Date;
   lianeRequest: ResolvedLianeRequest;
   tripModalVisible: boolean;
   setTripModalVisible: (v: boolean) => void;
-  launchTrip: (d: [Date, Date | undefined]) => void;
-  nextDayIndex: number;
+  launchTrip: (d: [Date, Date | undefined], from: string | undefined, to: string | undefined) => void;
 }) => {
-  const weekdays = lianeRequest.weekDays;
-  console.log("Init params", lianeRequest);
+  const defaultTimeDate = createDateFromStart((lianeRequest as any).when?.start) ?? initialDate;
 
   const [launchTripStep, setLaunchTripStep] = useState(0);
   const [selectedTime, setSelectedTime] = useState<[Date, Date | undefined]>([new Date(), undefined]);
   // @ts-ignore
-  const [selectedDay, setSelectedDay] = useState<DayOfWeekFlag>("0000000".substring(0, nextDayIndex) + "1" + "0000000".substring(nextDayIndex + 1));
+  const [selectedDay, setSelectedDay] = useState<DayOfWeekFlag>(getNextAvailableDay(lianeRequest.weekDays, (lianeRequest as any).when?.start));
+  const [from, SetFrom] = useState<RallyingPoint>(lianeRequest.wayPoints[0]);
+  const [to, SetTo] = useState<RallyingPoint>(lianeRequest.wayPoints[lianeRequest.wayPoints.length - 1]);
 
   const launch = () => {
     const todayIndex = (selectedTime[0].getDay() + 6) % 7;
-    let addDays = (selectedDay.indexOf("1") - todayIndex + 7) % 7;
 
-    if (addDays === 0 && selectedTime[0].valueOf() < new Date().valueOf()) {
-      addDays = 7;
+    let selectedDays = selectedDay
+      .split("")
+      .map((day, index) => (day === "1" ? index : -1))
+      .filter(index => index !== -1);
+
+    let firstDay = (selectedDays[0] - todayIndex + 7) % 7;
+    let returnDay = selectedDays.length > 1 ? (selectedDays[1] - todayIndex + 7) % 7 : firstDay;
+
+    if (firstDay === 0 && selectedTime[0].valueOf() < new Date().valueOf()) {
+      firstDay = 7;
     }
-    const departureTime = addSeconds(selectedTime[0], addDays * 3600 * 24);
-    const returnTime = selectedTime[1] ? addSeconds(selectedTime[1], addDays * 3600 * 24) : undefined;
-    launchTrip([departureTime, returnTime]);
+    const departureTime = addSeconds(selectedTime[0], firstDay * 3600 * 24);
+    const returnTime =
+      launchTripStep === 2
+        ? selectedTime[1]
+          ? addSeconds(selectedTime[1], returnDay * 3600 * 24)
+          : addSeconds(defaultTimeDate, returnDay * 3600 * 24)
+        : undefined;
+
+    launchTrip([departureTime, returnTime], from.id, to.id);
+  };
+
+  const switchDestination = () => {
+    const ToTemp = to;
+    SetTo(from);
+    SetFrom(ToTemp);
   };
 
   return (
@@ -476,12 +547,19 @@ const LaunchTripModal = ({
             <AppText style={styles.modalText}>Aller-simple</AppText>
             <View>
               <Row spacing={6}>
-                <DayOfTheWeekPicker selectedDays={selectedDay} onChangeDays={setSelectedDay} enabledDays={weekdays} singleOptionMode={true} />
+                <AppText style={[{ marginTop: 5 }, styles.modalText]}>{from.label}</AppText>
+                <AppPressableIcon name={"flip-2-outline"} onPress={switchDestination} />
+                <AppText style={[{ marginTop: 5 }, styles.modalText]}>{to.label}</AppText>
+              </Row>
+            </View>
+            <View>
+              <Row spacing={6}>
+                <DayOfTheWeekPicker selectedDays={selectedDay} onChangeDays={setSelectedDay} enabledDays={"1111111"} singleOptionMode={true} />
               </Row>
             </View>
             <AppText style={styles.modalText}>Départ à :</AppText>
             <Center>
-              <TimeWheelPicker date={initialDate} minuteStep={5} onChange={d => setSelectedTime([d, undefined])} />
+              <TimeWheelPicker date={defaultTimeDate} minuteStep={5} onChange={d => setSelectedTime([d, undefined])} />
             </Center>
             <Row style={{ justifyContent: "flex-end" }}>
               <AppPressableIcon name={"checkmark-outline"} onPress={launch} />
@@ -493,20 +571,27 @@ const LaunchTripModal = ({
             <AppText style={styles.modalText}>Aller-retour</AppText>
             <View>
               <Row spacing={6}>
-                <DayOfTheWeekPicker selectedDays={selectedDay} onChangeDays={setSelectedDay} enabledDays={weekdays} singleOptionMode={true} />
+                <AppText style={[{ marginTop: 5 }, styles.modalText]}>{from.label}</AppText>
+                <AppPressableIcon name={"flip-2-outline"} onPress={switchDestination} />
+                <AppText style={[{ marginTop: 5 }, styles.modalText]}>{to.label}</AppText>
+              </Row>
+            </View>
+            <View>
+              <Row spacing={6}>
+                <DayOfTheWeekPicker selectedDays={selectedDay} onChangeDays={setSelectedDay} enabledDays={"1111111"} dualOptionMode={true} />
               </Row>
             </View>
             <Row spacing={8} style={{ justifyContent: "space-evenly" }}>
               <Column>
                 <AppText style={styles.modalText}>Départ à :</AppText>
                 <Center>
-                  <TimeWheelPicker date={initialDate} minuteStep={5} onChange={d => setSelectedTime(v => [d, v[1]])} />
+                  <TimeWheelPicker date={defaultTimeDate} minuteStep={5} onChange={d => setSelectedTime(v => [d, v[1]])} />
                 </Center>
               </Column>
               <Column>
                 <AppText style={styles.modalText}>Retour à :</AppText>
                 <Center>
-                  <TimeWheelPicker minuteStep={5} onChange={d => setSelectedTime(v => [v[0], d])} />
+                  <TimeWheelPicker date={defaultTimeDate} minuteStep={5} onChange={d => setSelectedTime(v => [v[0], d])} />
                 </Center>
               </Column>
             </Row>


### PR DESCRIPTION
- **Afficher l’aperçu avant de reposter le trajet :**
    - Par défaut sélectionner le prochain jour prévu (par rapport à l’horaire actuelle)
    - Permettre la sélection de tous le jours de la semaine (y compris ceux pas prévu initialement)
    - Dans le cas d’un aller-retour :
        - permettre la sélection éventuelle de 2 jours
        - afficher un sélecteur d’horaire pour le retour
    - Afficher les points et permettre de les inverser
    - En fonction du jour et de l’horaire sélectionnée, ça prend le prochain créneau à partir de maintenant (pas de trajets dans le passé)
    - Permettre quand on est le créateur de trajet, de rouvrir la popup de modification du trajet